### PR TITLE
Set filetype to scss.css

### DIFF
--- a/ftdetect/scss.vim
+++ b/ftdetect/scss.vim
@@ -1,1 +1,1 @@
-au BufRead,BufNewFile *.scss	set filetype=scss
+au BufRead,BufNewFile *.scss	set filetype=scss.css


### PR DESCRIPTION
Hello,

I guess the title says it all.
It allows to have css-related things to work straight away with scss files.
Like css snippets of snipmate for example.

Have a nice day,
Mig
