### PR TITLE
Added support for highlighted TODOs in SCSS files

### DIFF
--- a/syntax/scss.vim
+++ b/syntax/scss.vim
@@ -32,7 +32,7 @@ syn match scssFunctionName " [[:alnum:]_-]\+" contained nextgroup=scssDefinition
 syn match scssReturn "@return" contained
 syn match scssInclude "@include" nextgroup=scssMixinName
 syn match scssExtend "@extend .*[;}]"me=e-1 contains=cssTagName,scssIdChar,scssClassChar
-syn keyword scssTodo TODO FIXME NOTE OPTIMIZE XXX contained containedIn=scssComment,cssComment:
+syn keyword scssTodo TODO FIXME NOTE OPTIMIZE XXX contained containedIn=scssComment,cssComment
 
 syn match scssColor "#[0-9A-Fa-f]\{3\}\>" contained
 syn match scssColor "#[0-9A-Fa-f]\{6\}\>" contained


### PR DESCRIPTION
Hi there,

Just added the support for highlighting TODOs in SCSS files. Those keywords (`TODO`, `FIXME`, `NOTE`, `OPTIMIZE`, `XXX`) are linked to the vim `todo`class. It's quite handy to be able to quickly spot TODO items in the code.
- Added a keyword line, specifying that those keyword are always contained, either in scssComments or cssComments
- And linked `scssTodo` to vim default `todo` class

And a quick preview... 
Before :
![before](https://f.cloud.github.com/assets/769918/369565/c6d7f5e6-a2da-11e2-8755-6adb8000accb.png)
And after : 
![after oneliner](https://f.cloud.github.com/assets/769918/369566/cfa558a8-a2da-11e2-8617-11b9d295a966.png)
![after nested](https://f.cloud.github.com/assets/769918/369567/d14b6170-a2da-11e2-8e4b-e2391d0931c0.png)

Cheers,
Paddy
