### PR TITLE
Set file type to scss, revert #17

### DIFF
--- a/ftdetect/scss.vim
+++ b/ftdetect/scss.vim
@@ -1,2 +1,2 @@
-au BufRead,BufNewFile *.scss	set filetype=scss.css
+au BufRead,BufNewFile *.scss setf=scss
 au BufEnter *.scss :syntax sync fromstart


### PR DESCRIPTION
My opinion is that the file type of SCSS files should be `scss`, not `scss.css`. Mostly because the two syntaxes available for Sass; SCSS and Sass, use the file extensions `.scss` and `.sass`, but also because several other plugins, such as [vim-css-color](https://github.com/ap/vim-css-color), is affected by the Sass syntax and file type set by this plugin.

When the file type is set to `scss.css`, these other plugins will not detect that the SCSS file is indeed a SCSS file. This results in the plugins being unable to do their job, which is not good.

The merged pull request #17 allowed "css-related things to work straight away with scss files", but I think that there are better ways to make CSS-related things work out of the box than changing the file type to something that breaks compatibility with other plugins.
