### PR TITLE
Support @forward and @use

### DIFF
--- a/example.scss
+++ b/example.scss
@@ -1,8 +1,12 @@
 // @forward and @use
 @forward "foo.scss";
 @use "foo.scss";
+
 @forward "bar.scss" as bar-*;
 @use "bar.scss" as *;
+
+@forward "baz.scss" with ($grey: #a4a4a4);
+@use "baz.scss" with ($grey: #686868);
 
 // Nested Rules
 

--- a/example.scss
+++ b/example.scss
@@ -1,6 +1,8 @@
 // @forward and @use
-@forward "foobar.scss";
-@use "foobar.scss";
+@forward "foo.scss";
+@use "foo.scss";
+@forward "bar.scss" as bar-*;
+@use "bar.scss" as *;
 
 // Nested Rules
 

--- a/example.scss
+++ b/example.scss
@@ -1,3 +1,7 @@
+// @forward and @use
+@forward "foobar.scss";
+@use "foobar.scss";
+
 // Nested Rules
 
 #main p {

--- a/syntax/scss.vim
+++ b/syntax/scss.vim
@@ -145,9 +145,14 @@ syn match scssExtendedSelector "[^;]\+" contained contains=cssTagName,cssPseudoC
 syn match scssOptional "!optional" contained
 
 syn match scssImport "@import" nextgroup=scssUrlList
-syn match scssForward "@forward" nextgroup=scssUrlList
-syn match scssUse "@use" nextgroup=scssUrlList
-syn match scssUrlList "[^;]\+" contained contains=cssString.*,cssMediaType,cssURL
+syn match scssImportList "[^;]\+" contained contains=cssString.*,cssMediaType,cssURL
+
+syn match scssForward "@forward" nextgroup=scssForwardUseParameters
+syn match scssUse "@use" nextgroup=scssForwardUseParameters
+syn match scssForwardUseParameters "[^;]\+" contained contains=cssString.*,cssMediaType,cssURL,scssAs
+
+syn match scssAs "as" contained nextgroup=scssNamespace
+syn match scssNamespace "[^;]\+" contained
 
 syn match scssSelectorChar "\(#\|\.\|%\)\([[:alnum:]_-]\|#{.*}\)\@=" nextgroup=scssSelectorName containedin=cssMediaBlock,cssPseudoClassFn
 syn match scssSelectorName "\([[:alnum:]_-]\|#{[^}]*}\)\+" contained contains=scssInterpolation
@@ -217,6 +222,9 @@ hi def link scssInterpolationDelimiter Delimiter
 hi def link scssImport    Include
 hi def link scssForward   Include
 hi def link scssUse       Include
+hi def link scssAs        Include
+hi def link scssWith      Include
+hi def link scssNamespace Identifier
 hi def link scssTodo      Todo
 hi def link scssAtRoot    Keyword
 hi def link scssMapParens Delimiter

--- a/syntax/scss.vim
+++ b/syntax/scss.vim
@@ -149,10 +149,12 @@ syn match scssImportList "[^;]\+" contained contains=cssString.*,cssMediaType,cs
 
 syn match scssForward "@forward" nextgroup=scssForwardUseParameters
 syn match scssUse "@use" nextgroup=scssForwardUseParameters
-syn match scssForwardUseParameters "[^;]\+" contained contains=cssString.*,cssMediaType,cssURL,scssAs
+syn match scssForwardUseParameters "[^;]\+" contained contains=cssString.*,cssMediaType,cssURL,scssAs,scssWith
 
 syn match scssAs "as" contained nextgroup=scssNamespace
 syn match scssNamespace "[^;]\+" contained
+
+syn match scssWith "with" contained
 
 syn match scssSelectorChar "\(#\|\.\|%\)\([[:alnum:]_-]\|#{.*}\)\@=" nextgroup=scssSelectorName containedin=cssMediaBlock,cssPseudoClassFn
 syn match scssSelectorName "\([[:alnum:]_-]\|#{[^}]*}\)\+" contained contains=scssInterpolation

--- a/syntax/scss.vim
+++ b/syntax/scss.vim
@@ -144,7 +144,7 @@ syn match scssExtend "@extend" nextgroup=scssExtendedSelector skipwhite containe
 syn match scssExtendedSelector "[^;]\+" contained contains=cssTagName,cssPseudoClass,scssOptional,scssSelectorChar skipwhite
 syn match scssOptional "!optional" contained
 
-syn match scssImport "@import" nextgroup=scssUrlList
+syn match scssImport "@import" nextgroup=scssImportList
 syn match scssImportList "[^;]\+" contained contains=cssString.*,cssMediaType,cssURL
 
 syn match scssForward "@forward" nextgroup=scssForwardUseParameters

--- a/syntax/scss.vim
+++ b/syntax/scss.vim
@@ -36,7 +36,7 @@ endif
 " override @font-face blocks to allow scss elements inside
 syn region cssFontDescriptorBlock contained transparent matchgroup=cssBraces start="{" end="}" contains=cssError,cssUnicodeEscape,cssFontProp,cssFontAttr,cssCommonAttr,cssStringQ,cssStringQQ,cssFontDescriptorProp,cssValue.*,cssFontDescriptorFunction,cssUnicodeRange,cssFontDescriptorAttr,@comment,scssDefinition,scssFunction,scssVariable,@scssControl,scssDebug,scssError,scssWarn
 
-syn region scssDefinition matchgroup=cssBraces start='{' end='}' contains=cssString.*,cssInclude,cssFontDescriptor,scssAtRootStatement,@comment,scssDefinition,scssProperty,scssSelector,scssVariable,scssImport,scssExtend,scssInclude,scssInterpolation,scssFunction,@scssControl,scssWarn,scssError,scssDebug,scssReturn containedin=cssMediaBlock fold
+syn region scssDefinition matchgroup=cssBraces start='{' end='}' contains=cssString.*,cssInclude,cssFontDescriptor,scssAtRootStatement,@comment,scssDefinition,scssProperty,scssSelector,scssVariable,scssImport,scssForward,scssUse,scssExtend,scssInclude,scssInterpolation,scssFunction,@scssControl,scssWarn,scssError,scssDebug,scssReturn containedin=cssMediaBlock fold
 
 syn match scssSelector _^\zs\([^:@]\|:[^ ]\|['"].*['"]\)\+{\@=_ contained contains=@scssSelectors
 syn match scssSelector "^\s*\zs\([^:@{]\|:[^ ]\|['"].*['"]\)\+\_$" contained contains=@scssSelectors
@@ -143,8 +143,11 @@ syn match scssReturn "@return" contained
 syn match scssExtend "@extend" nextgroup=scssExtendedSelector skipwhite containedin=cssMediaBlock
 syn match scssExtendedSelector "[^;]\+" contained contains=cssTagName,cssPseudoClass,scssOptional,scssSelectorChar skipwhite
 syn match scssOptional "!optional" contained
-syn match scssImport "@import" nextgroup=scssImportList
-syn match scssImportList "[^;]\+" contained contains=cssString.*,cssMediaType,cssURL
+
+syn match scssImport "@import" nextgroup=scssUrlList
+syn match scssForward "@forward" nextgroup=scssUrlList
+syn match scssUse "@use" nextgroup=scssUrlList
+syn match scssUrlList "[^;]\+" contained contains=cssString.*,cssMediaType,cssURL
 
 syn match scssSelectorChar "\(#\|\.\|%\)\([[:alnum:]_-]\|#{.*}\)\@=" nextgroup=scssSelectorName containedin=cssMediaBlock,cssPseudoClassFn
 syn match scssSelectorName "\([[:alnum:]_-]\|#{[^}]*}\)\+" contained contains=scssInterpolation
@@ -212,6 +215,8 @@ hi def link scssForKeyword  Repeat
 hi def link scssEachKeyword Repeat
 hi def link scssInterpolationDelimiter Delimiter
 hi def link scssImport    Include
+hi def link scssForward   Include
+hi def link scssUse       Include
 hi def link scssTodo      Todo
 hi def link scssAtRoot    Keyword
 hi def link scssMapParens Delimiter


### PR DESCRIPTION
This PR adds basic support for the @forward and @use rules, which were previously unsupported.

I followed the syntax highlighting rules on the https://sass-lang.com website; the "as" and "with" keywords are highlighted in the same color as "@forward" and "@use", and namespaces are highlighted in the same color as variables.

The only thing that doesn't currently work is parenthesized blocks of SCSS following a "with". I couldn't figure out a way to say "apply the regular syntax rules of the filetype within these parentheses", which feels like the kind of thing that should be easy but probably isn't.

I also updated the example.scss file with usage examples of the newly-supported rules.

This is my first time working with Vim syntax definitions; I was putting things together largely by scanning the built-in help and experimenting, so it's possible I've made a few beginner errors. If so please correct me.